### PR TITLE
Using $HOME of jenkins slave instead of ${JENKINS_HOME}

### DIFF
--- a/src/info/pedrocesar/utils.groovy
+++ b/src/info/pedrocesar/utils.groovy
@@ -5,8 +5,8 @@ import com.cloudbees.groovy.cps.NonCPS
 @NonCPS
 def installMetarunner(String metarunner){
   sh """ 
-  git clone https://github.com/${metarunner}/${metarunner}.git ${JENKINS_HOME}/.${metarunner}
-  cd ${JENKINS_HOME}/.${metarunner}
+  git clone https://github.com/${metarunner}/${metarunner}.git $HOME/.${metarunner}
+  cd $HOME/.${metarunner}
   src/configure --without-ssl && make -C src
   """
 }
@@ -18,14 +18,14 @@ def installVersion(String metarunner, String version) {
 
 @NonCPS
 def deleteVersion(String metarunner, String version) {
-  File directory = new File("${JENKINS_HOME}/.${metarunner}/versions/${version}")
+  File directory = new File("$HOME/.${metarunner}/versions/${version}")
   
   directory.deleteDir()
 }
 
 @NonCPS
 def purgeAllVersions(String metarunner) {
-  File directory = new File("${JENKINS_HOME}/.${metarunner}/versions/")
+  File directory = new File("$HOME/.${metarunner}/versions/")
 
   directory.listFiles().each{
     it.deleteDir()

--- a/vars/withNodenv.groovy
+++ b/vars/withNodenv.groovy
@@ -6,25 +6,25 @@ def call(version='6.14.4', method=null, cl) {
 
   print "Setting up NodeJS version ${version}!"
   
-  if (!fileExists("${JENKINS_HOME}/.${metarunner}/bin/${metarunner}")) {
+  if (!fileExists("$HOME/.${metarunner}/bin/${metarunner}")) {
     installNodenv(metarunner)
-    sh "git clone https://github.com/${metarunner}/node-build.git ${JENKINS_HOME}/.${metarunner}/plugins/node-build"
+    sh "git clone https://github.com/${metarunner}/node-build.git $HOME/.${metarunner}/plugins/node-build"
   }
 
-  if (!fileExists("${JENKINS_HOME}/.${metarunner}/versions/${version}/")) {
-    withEnv(["PATH=${JENKINS_HOME}/.${metarunner}/bin/:$PATH"]) {
+  if (!fileExists("$HOME/.${metarunner}/versions/${version}/")) {
+    withEnv(["PATH=$HOME/.${metarunner}/bin/:$PATH"]) {
       utils.installVersion(metarunner, version)
     }
   }
 
-  withEnv(["PATH=${JENKINS_HOME}/.${metarunner}/shims:${JENKINS_HOME}/.${metarunner}/bin/:$PATH", "NODENV_SHELL=sh"]) {
+  withEnv(["PATH=$HOME/.${metarunner}/shims:$HOME/.${metarunner}/bin/:$PATH", "NODENV_SHELL=sh"]) {
     sh "${metarunner} rehash && ${metarunner} local ${version}"
     cl()
   }
 
   if (method == 'clean') {
     print "Removing NodeJS ${version}!!!"
-    withEnv(["PATH=${JENKINS_HOME}/.${metarunner}/bin/:$PATH"]) {
+    withEnv(["PATH=$HOME/.${metarunner}/bin/:$PATH"]) {
       utils.deleteVersion(metarunner, version)
     }
   } 

--- a/vars/withPyenv.groovy
+++ b/vars/withPyenv.groovy
@@ -6,24 +6,24 @@ def call(version='3.7.0', method=null, cl) {
 
   print "Setting up Python version ${version}!"
   
-  if (!fileExists("${JENKINS_HOME}/.${metarunner}/bin/${metarunner}")) {
+  if (!fileExists("$HOME/.${metarunner}/bin/${metarunner}")) {
     installPyenv(metarunner)
   }
 
-  if (!fileExists("${JENKINS_HOME}/.${metarunner}/versions/${version}/")) {
-    withEnv(["PATH=${JENKINS_HOME}/.${metarunner}/bin/:$PATH"]) {
+  if (!fileExists("$HOME/.${metarunner}/versions/${version}/")) {
+    withEnv(["PATH=$HOME/.${metarunner}/bin/:$PATH"]) {
       utils.installVersion(metarunner, version)
     }
   }
 
-  withEnv(["PATH=${JENKINS_HOME}/.${metarunner}/shims:${JENKINS_HOME}/.${metarunner}/bin/:$PATH", "NODENV_SHELL=sh"]) {
+  withEnv(["PATH=$HOME/.${metarunner}/shims:$HOME/.${metarunner}/bin/:$PATH", "NODENV_SHELL=sh"]) {
     sh "${metarunner} rehash && ${metarunner} local ${version}"
     cl()
   }
 
   if (method == 'clean') {
     print "Removing Python ${version}!!!"
-    withEnv(["PATH=${JENKINS_HOME}/.${metarunner}/bin/:$PATH"]) {
+    withEnv(["PATH=$HOME/.${metarunner}/bin/:$PATH"]) {
       utils.deleteVersion(metarunner, version)
     }
   } 

--- a/vars/withRbenv.groovy
+++ b/vars/withRbenv.groovy
@@ -6,25 +6,25 @@ def call(version='2.5.1', method=null, cl) {
 
   print "Setting up Ruby version ${version}!"
   
-  if (!fileExists("${JENKINS_HOME}/.${metarunner}/bin/${metarunner}")) {
+  if (!fileExists("$HOME/.${metarunner}/bin/${metarunner}")) {
     installRbenv(metarunner)
-    sh "git clone https://github.com/${metarunner}/ruby-build.git ${JENKINS_HOME}/.${metarunner}/plugins/ruby-build"
+    sh "git clone https://github.com/${metarunner}/ruby-build.git $HOME/.${metarunner}/plugins/ruby-build"
   }
 
-  if (!fileExists("${JENKINS_HOME}/.${metarunner}/versions/${version}/")) {
-    withEnv(["PATH=${JENKINS_HOME}/.${metarunner}/bin/:$PATH"]) {
+  if (!fileExists("$HOME/.${metarunner}/versions/${version}/")) {
+    withEnv(["PATH=$HOME/.${metarunner}/bin/:$PATH"]) {
       utils.installVersion(metarunner, version)
     }
   }
 
-  withEnv(["PATH=${JENKINS_HOME}/.${metarunner}/shims:${JENKINS_HOME}/.${metarunner}/bin/:$PATH", "NODENV_SHELL=sh"]) {
+  withEnv(["PATH=$HOME/.${metarunner}/shims:$HOME/.${metarunner}/bin/:$PATH", "NODENV_SHELL=sh"]) {
     sh "${metarunner} rehash && ${metarunner} local ${version}"
     cl()
   }
 
   if (method == 'clean') {
     print "Removing Ruby ${version}!!!"
-    withEnv(["PATH=${JENKINS_HOME}/.${metarunner}/bin/:$PATH"]) {
+    withEnv(["PATH=$HOME/.${metarunner}/bin/:$PATH"]) {
       utils.deleteVersion(metarunner, version)
     }
   } 


### PR DESCRIPTION
This is a possible fix for issue #1
${JENKINS_HOME} will reference a path on the jenkins master, this path may not be valid for jenkins agents & therefore all your checks for an existing metarunner install do not work as intedended